### PR TITLE
chore: clippy --fix

### DIFF
--- a/src/keccak/mod.rs
+++ b/src/keccak/mod.rs
@@ -187,7 +187,6 @@ impl<'v, F: Field> KeccakChip<'v, F> {
         // bottom layer hashes
         let mut hashes = leaves
             .chunks(2)
-            .into_iter()
             .map(|pair| {
                 let leaves_concat = [&pair[0][..], &pair[1][..]].concat();
                 self.keccak_fixed_len(ctx, gate, leaves_concat, None)

--- a/src/mpt/mod.rs
+++ b/src/mpt/mod.rs
@@ -659,7 +659,6 @@ impl<'v, F: Field> MPTChip<'v, F> {
         let key_hex_rlc = self.rlp.rlc.compute_rlc_fixed_len(ctx, self.gate(), key_hexs);
         let fragment_rlcs = key_frag
             .into_iter()
-            .into_iter()
             .zip(witness.frag_lens.into_iter())
             .map(|(key_frag, frag_lens)| {
                 self.rlc().compute_rlc(ctx, self.gate(), key_frag.nibbles, frag_lens)

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -54,7 +54,7 @@ pub fn get_block_storage_input(
         .unwrap();
 
     for storage_pf in pf.storage_proof.iter() {
-        println!("key: {:?}, is_assigned_slot: {}", storage_pf.key, is_assigned_slot(&storage_pf));
+        println!("key: {:?}, is_assigned_slot: {}", storage_pf.key, is_assigned_slot(storage_pf));
     }
 
     let acct_pf = MPTFixedKeyInput {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -570,7 +570,7 @@ impl<F: Field> Circuit<F> for EthBlockStorageCircuit<F> {
                                     .iter()
                                     .flat_map(|(slot, value)| slot.iter().chain(value.iter())),
                             )
-                            .map(|acell| acell.cell().clone()),
+                            .map(|acell| *acell.cell()),
                     );
 
                     #[cfg(feature = "display")]


### PR DESCRIPTION
apply some clippy fixes via
`cargo +nightly clippy --fix -Z unstable-options --allow-dirty --allow-staged`

there still some hints that require manual changes, for examples needless lifetimes.