### PR TITLE
feat: use retry Http provider

### DIFF
--- a/axiom-eth/Cargo.toml
+++ b/axiom-eth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-eth"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/axiom-eth/Cargo.toml
+++ b/axiom-eth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-eth"
-version = "0.2.1"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/axiom-eth/src/batch_query/response/account.rs
+++ b/axiom-eth/src/batch_query/response/account.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use ethers_core::types::Address;
 #[cfg(feature = "providers")]
-use ethers_providers::{Http, Provider};
+use ethers_providers::{JsonRpcClient, Provider};
 use halo2_base::{
     gates::{GateInstructions, RangeChip, RangeInstructions},
     halo2_proofs::halo2curves::bn256::G1Affine,
@@ -257,8 +257,8 @@ impl MultiAccountCircuit {
 
     /// Creates circuit inputs from a JSON-RPC provider.
     #[cfg(feature = "providers")]
-    pub fn from_provider(
-        provider: &Provider<Http>,
+    pub fn from_provider<P: JsonRpcClient>(
+        provider: &Provider<P>,
         block_responses: Vec<(Fr, u32)>,
         queries: Vec<(u64, Address)>,
         not_empty: Vec<bool>,

--- a/axiom-eth/src/batch_query/response/block_header.rs
+++ b/axiom-eth/src/batch_query/response/block_header.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use ethers_core::types::{Block, H256};
 #[cfg(feature = "providers")]
-use ethers_providers::{Http, Provider};
+use ethers_providers::{JsonRpcClient, Provider};
 use halo2_base::{
     gates::{GateInstructions, RangeChip, RangeInstructions},
     halo2_proofs::halo2curves::bn256::G1Affine,
@@ -341,8 +341,8 @@ impl MultiBlockCircuit {
     ///
     /// Assumes that `network` is the same as the provider's network.
     #[cfg(feature = "providers")]
-    pub fn from_provider(
-        provider: &Provider<Http>,
+    pub fn from_provider<P: JsonRpcClient>(
+        provider: &Provider<P>,
         block_numbers: Vec<u64>,
         not_empty: Vec<bool>,
         network: Network,

--- a/axiom-eth/src/batch_query/response/storage.rs
+++ b/axiom-eth/src/batch_query/response/storage.rs
@@ -30,7 +30,7 @@ use ethers_core::{
     utils::keccak256,
 };
 #[cfg(feature = "providers")]
-use ethers_providers::{Http, Provider};
+use ethers_providers::{JsonRpcClient, Provider};
 use halo2_base::{
     gates::{GateInstructions, RangeChip, RangeInstructions},
     halo2_proofs::halo2curves::bn256::G1Affine,
@@ -231,8 +231,8 @@ impl MultiStorageCircuit {
 
     /// Creates circuit inputs from a JSON-RPC provider.
     #[cfg(feature = "providers")]
-    pub fn from_provider(
-        provider: &Provider<Http>,
+    pub fn from_provider<P: JsonRpcClient>(
+        provider: &Provider<P>,
         block_responses: Vec<(Fr, u32)>,
         account_responses: Vec<(Fr, Address)>,
         queries: Vec<(u64, Address, H256)>,

--- a/axiom-eth/src/batch_query/tests/mod.rs
+++ b/axiom-eth/src/batch_query/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::providers::{GOERLI_PROVIDER_URL, MAINNET_PROVIDER_URL};
-use ethers_providers::{Http, Middleware, Provider};
+use ethers_providers::{Http, Middleware, Provider, RetryClient};
 use std::env::var;
 use tokio::runtime::Runtime;
 
@@ -12,16 +12,16 @@ mod row_consistency;
 mod scheduler;
 mod storage;
 
-fn setup_provider() -> Provider<Http> {
+fn setup_provider() -> Provider<RetryClient<Http>> {
     let infura_id = var("INFURA_ID").expect("INFURA_ID environmental variable not set");
     let provider_url = format!("{MAINNET_PROVIDER_URL}{infura_id}");
-    Provider::<Http>::try_from(provider_url.as_str()).expect("could not instantiate HTTP Provider")
+    Provider::new_client(&provider_url, 10, 500).expect("could not instantiate HTTP Provider")
 }
 
-fn setup_provider_goerli() -> Provider<Http> {
+fn setup_provider_goerli() -> Provider<RetryClient<Http>> {
     let infura_id = var("INFURA_ID").expect("INFURA_ID environmental variable not set");
     let provider_url = format!("{GOERLI_PROVIDER_URL}{infura_id}");
-    Provider::<Http>::try_from(provider_url.as_str()).expect("could not instantiate HTTP Provider")
+    Provider::new_client(&provider_url, 10, 500).expect("could not instantiate HTTP Provider")
 }
 
 fn get_latest_block_number() -> u64 {

--- a/axiom-eth/src/block_header/mod.rs
+++ b/axiom-eth/src/block_header/mod.rs
@@ -17,7 +17,7 @@ use core::{
     marker::PhantomData,
 };
 #[cfg(feature = "providers")]
-use ethers_providers::{Http, Provider};
+use ethers_providers::{JsonRpcClient, Provider};
 use halo2_base::{
     gates::{builder::GateThreadBuilder, GateInstructions, RangeChip, RangeInstructions},
     halo2_proofs::halo2curves::bn256::Fr,
@@ -516,8 +516,8 @@ pub struct EthBlockHeaderChainCircuit<F> {
 
 impl<F: Field> EthBlockHeaderChainCircuit<F> {
     #[cfg(feature = "providers")]
-    pub fn from_provider(
-        provider: &Provider<Http>,
+    pub fn from_provider<P: JsonRpcClient>(
+        provider: &Provider<P>,
         network: Network,
         start_block_number: u32,
         num_blocks: u32,

--- a/axiom-eth/src/storage/mod.rs
+++ b/axiom-eth/src/storage/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use ethers_core::types::{Address, Block, H256, U256};
 #[cfg(feature = "providers")]
-use ethers_providers::{Http, Provider};
+use ethers_providers::{JsonRpcClient, Provider};
 use halo2_base::{
     gates::{builder::GateThreadBuilder, GateInstructions, RangeChip, RangeInstructions},
     halo2_proofs::halo2curves::bn256::Fr,
@@ -634,8 +634,8 @@ pub struct EthBlockStorageCircuit {
 
 impl EthBlockStorageCircuit {
     #[cfg(feature = "providers")]
-    pub fn from_provider(
-        provider: &Provider<Http>,
+    pub fn from_provider<P: JsonRpcClient>(
+        provider: &Provider<P>,
         block_number: u32,
         address: Address,
         slots: Vec<H256>,

--- a/axiom-eth/src/storage/tests.rs
+++ b/axiom-eth/src/storage/tests.rs
@@ -37,8 +37,8 @@ fn get_test_circuit(network: Network, num_slots: usize) -> EthBlockStorageCircui
         Network::Mainnet => format!("{MAINNET_PROVIDER_URL}{infura_id}"),
         Network::Goerli => format!("{GOERLI_PROVIDER_URL}{infura_id}"),
     };
-    let provider = Provider::<Http>::try_from(provider_url.as_str())
-        .expect("could not instantiate HTTP Provider");
+    let provider =
+        Provider::new_client(&provider_url, 10, 500).expect("could not instantiate HTTP Provider");
     let addr;
     let block_number;
     match network {


### PR DESCRIPTION
switch all functions to use `JsonRpcClient` trait instead of hardcoded `Http`