### PR TITLE
Adjust visibility of constants to support halo2-scaffold

### DIFF
--- a/axiom-eth/src/keccak/mod.rs
+++ b/axiom-eth/src/keccak/mod.rs
@@ -59,8 +59,8 @@ mod builder;
 mod tests;
 
 pub use builder::*;
-pub(crate) type FixedLenRLCs<F> = Vec<(RlcFixedTrace<F>, RlcFixedTrace<F>)>;
-pub(crate) type VarLenRLCs<F> = Vec<(RlcTrace<F>, RlcFixedTrace<F>)>;
+pub type FixedLenRLCs<F> = Vec<(RlcFixedTrace<F>, RlcFixedTrace<F>)>;
+pub type VarLenRLCs<F> = Vec<(RlcTrace<F>, RlcFixedTrace<F>)>;
 
 pub(crate) const KECCAK_CONTEXT_ID: usize = usize::MAX;
 

--- a/axiom-eth/src/lib.rs
+++ b/axiom-eth/src/lib.rs
@@ -50,7 +50,7 @@ pub mod util;
 #[cfg(feature = "providers")]
 pub mod providers;
 
-pub(crate) const ETH_LOOKUP_BITS: usize = 8; // always want 8 to range check bytes
+pub const ETH_LOOKUP_BITS: usize = 8; // always want 8 to range check bytes
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]


### PR DESCRIPTION
Running [halo2-scaffold](https://github.com/axiom-crypto/halo2-scaffold) fails due to visibility issues
After applying this fix and modifying halo2-scaffold Cargo.toml to use the updated repository with this fix it now works

*Note: changing visibility here is one solution, another approach would be to modify halo2-scaffold*

### Analysis

running halo2-scaffold

`cargo run --example fixed_len_keccak -- --name fixed_len_keccak -k 10 mock`

produces

```
halo2-scaffold (main)$ cargo run --example fixed_len_keccak -- --name fixed_len_keccak -k 10 verify
    Updating git repository `https://github.com/axiom-crypto/axiom-eth.git`
   Compiling halo2-scaffold v0.2.0 (/Users/johnwhitton/me/axiom/halo2-scaffold)
error[E0603]: type alias `FixedLenRLCs` is private
   --> src/scaffold/mod.rs:106:18
    |
106 |         keccak::{FixedLenRLCs, KeccakChip, VarLenRLCs},
    |                  ^^^^^^^^^^^^ private type alias
    |
note: the type alias `FixedLenRLCs` is defined here
   --> /Users/johnwhitton/.cargo/git/checkouts/axiom-eth-de965aed218ff108/dcd3ef9/axiom-eth/src/keccak/mod.rs:62:1
    |
62  | pub(crate) type FixedLenRLCs<F> = Vec<(RlcFixedTrace<F>, RlcFixedTrace<F>)>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0603]: type alias `VarLenRLCs` is private
   --> src/scaffold/mod.rs:106:44
    |
106 |         keccak::{FixedLenRLCs, KeccakChip, VarLenRLCs},
    |                                            ^^^^^^^^^^ private type alias
    |
note: the type alias `VarLenRLCs` is defined here
   --> /Users/johnwhitton/.cargo/git/checkouts/axiom-eth-de965aed218ff108/dcd3ef9/axiom-eth/src/keccak/mod.rs:63:1
    |
63  | pub(crate) type VarLenRLCs<F> = Vec<(RlcTrace<F>, RlcFixedTrace<F>)>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0603]: constant `ETH_LOOKUP_BITS` is private
   --> src/scaffold/mod.rs:112:37
    |
112 |         EthChip, EthCircuitBuilder, ETH_LOOKUP_BITS,
    |                                     ^^^^^^^^^^^^^^^ private constant
    |
note: the constant `ETH_LOOKUP_BITS` is defined here
   --> /Users/johnwhitton/.cargo/git/checkouts/axiom-eth-de965aed218ff108/dcd3ef9/axiom-eth/src/lib.rs:53:1
    |
53  | pub(crate) const ETH_LOOKUP_BITS: usize = 8; // always want 8 to range check bytes
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0603`.
error: could not compile `halo2-scaffold` due to 3 previous errors
```
After applying this fix and modifying halo2-scaffold Cargo.toml to use the updated repository with this fix it now works
```
# These are just for making proving executables, if you are just building a library you don't need them as dependencies in your project
# axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", branch = "community-edition", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
axiom-eth = { path = "../axiom-eth/axiom-eth", default-features = false, features = ["halo2-axiom", "aggregation", "evm", "clap"] }
```

and produces
```
halo2-scaffold (main)$ cargo run --example fixed_len_keccak -- --name fixed_len_keccak -k 10 verify
    Finished dev [optimized + debuginfo] target(s) in 0.58s
     Running `target/debug/examples/fixed_len_keccak --name fixed_len_keccak -k 10 verify`
read params from ./params/kzg_bn254_10.srs
Universal trusted setup (unsafe!) available at: params/kzg_bn254_10.srs
Output: c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
Gate Chip | Phase 0: 32 advice cells , 0 lookup advice cells
Total 0 fixed cells
k: 10, extended_k: 12
Snark verified successfully!
```
