### PR TITLE
Parse arbitrary RLPs.

### DIFF
--- a/axiom-eth/src/rlp/builder.rs
+++ b/axiom-eth/src/rlp/builder.rs
@@ -608,7 +608,7 @@ mod circuit_builder {
     }
 
     /// A wrapper around RlcCircuitBuilder where Gate is replaced by Range in the circuit
-    pub struct RlpCircuitBuilder<F: ScalarField, FnPhase1>(RlcCircuitBuilder<F, FnPhase1>)
+    pub struct RlpCircuitBuilder<F: ScalarField, FnPhase1>(pub RlcCircuitBuilder<F, FnPhase1>)
     where
         FnPhase1: FnSynthesize<F>;
 

--- a/axiom-eth/src/rlp/mod.rs
+++ b/axiom-eth/src/rlp/mod.rs
@@ -43,7 +43,6 @@ pub fn witness_subarray<F: ScalarField>(
     // `u32` should be enough for array indices
     let [start_id, sub_len] = [start_id, sub_len].map(|fe| fe.get_lower_32() as usize);
     debug_assert!(sub_len <= max_len);
-    println!("About to have problem at {} {}", start_id, sub_len);
     ctx.assign_witnesses(
         array[start_id..start_id + sub_len]
             .iter()
@@ -847,7 +846,6 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
                 rlp_array.iter().copied().take(running_max_len + 1),
                 prefix_idx,
             );
-            println!("Prefix: {:?}", prefix);
             let prefix_parsed = self.parse_rlp_prefix(ctx, prefix); // constrained correct
 
             let mut len_len = prefix_parsed.len_len;

--- a/axiom-eth/src/rlp/mod.rs
+++ b/axiom-eth/src/rlp/mod.rs
@@ -43,6 +43,7 @@ pub fn witness_subarray<F: ScalarField>(
     // `u32` should be enough for array indices
     let [start_id, sub_len] = [start_id, sub_len].map(|fe| fe.get_lower_32() as usize);
     debug_assert!(sub_len <= max_len);
+    println!("About to have problem at {} {}", start_id, sub_len);
     ctx.assign_witnesses(
         array[start_id..start_id + sub_len]
             .iter()
@@ -395,6 +396,9 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
             Constant(self.gate().get_field_element(55)),
         );
 
+        // If item is byte literal, 0
+        // If item is short, len
+        // If item is long, len_len
         let next_len = self.gate().select(
             ctx,
             Existing(len_len),
@@ -402,6 +406,8 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
             Existing(is_big),
         );
 
+        // If item is big, this is the length of the length field
+        // Else 0
         let len_len = self.gate().mul(
             ctx,
             Existing(len_len),
@@ -782,8 +788,6 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         max_item_lens: &[usize],
         is_variable_len: bool,
     ) -> RlpOfRlpTraceWitness<F> {
-        //println!("Start decompose_rlp_of_rlp_phase0");
-
 
         let max_rlp_array_len = rlp_array.len();
         let max_len_len = max_rlp_len_len(max_rlp_array_len);
@@ -794,14 +798,26 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         let len_len = prefix_parsed.len_len;
         self.range.check_less_than_safe(ctx, len_len, (max_len_len + 1) as u64);
 
+        // len_byte_val -- len if big, 0 otherwise
         let (len_cells, len_byte_val) = self.parse_rlp_len(ctx, &rlp_array, len_len, max_len_len);
 
-        let list_payload_len = self.gate().select(
+        // 0 if byte literal
+        // else len
+        let mut list_payload_len = self.gate().select(
             ctx,
             Existing(len_byte_val),
             Existing(prefix_parsed.next_len),
             Existing(prefix_parsed.is_big),
         );
+
+        //list_payload_len = self.gate().select(
+        //    ctx,
+        //    list_payload_len,
+        //    Constant(F::one()),
+        //    prefix_parsed.
+        //)
+
+        // if byte literal -- might be off by 1
         self.range.check_less_than_safe(
             ctx,
             list_payload_len,
@@ -809,6 +825,10 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         );
 
         // this is automatically <= max_rlp_array_len
+        // if end: should be 0
+        // if literal: 1
+        // if short: 1 + len
+        // if long: 1 + len_len + len
         let rlp_len = self
             .gate()
             .sum(ctx, [Constant(F::one()), Existing(len_len), Existing(list_payload_len)]);
@@ -819,12 +839,12 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         let mut running_max_len = max_len_len + 1; 
 
         for &max_item_len in max_item_lens {
-            // compare lines 625-712
             let mut prefix = self.gate().select_from_idx(
                 ctx,
                 rlp_array.iter().copied().take(running_max_len + 1),
                 prefix_idx,
             );
+            println!("Prefix: {:?}", prefix);
             let prefix_parsed = self.parse_rlp_prefix(ctx, prefix);
 
             let mut len_len = prefix_parsed.len_len;
@@ -832,6 +852,7 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
             self.range.check_less_than_safe(ctx, len_len, (max_item_len_len + 1) as u64);
             
             let len_start_id = *prefix_parsed.is_not_literal.value() + prefix_idx.value();
+            // len_cells is empty if terminal, literal, or short
             let len_cells = witness_subarray(
                 ctx,
                 &rlp_array,
@@ -840,9 +861,12 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
                 max_item_len_len,
             );
 
+            // 0 if terminal, literal or short
+            // len if long
             let len_byte_val = evaluate_byte_array(ctx, self.gate(), &len_cells, len_len);
 
-
+            // len if short or long
+            // 0 if terminal or literal
             let mut item_len = self.gate().select(
                 ctx,
                 len_byte_val,
@@ -850,22 +874,71 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
                 prefix_parsed.is_big,
             );
 
-            let mut prefix_idx_val = F::from(0u64); // to be simplified if possible
+            // len if short or long
+            // 1 if terminal or literal
+            item_len = self.gate().select(
+                ctx,
+                item_len,
+                Constant(F::one()),
+                prefix_parsed.is_not_literal,
+            );
+
+
+            // prefix_len is 0 if literal
+            // 1 otherwise
+            let mut prefix_len = prefix_parsed.is_not_literal;
+
+
+            if is_variable_len{
+                let item_in_list = self.range.is_less_than(
+                    ctx,
+                    prefix_idx,
+                    rlp_len,
+                    bit_length(max_rlp_array_len as u64),
+                );
+
+                // len if short or long
+                // 1 if literal
+                // 0 if terminal
+                item_len = self.gate().select(
+                    ctx,
+                    item_len,
+                    Constant(F::zero()),
+                    item_in_list,
+                );
+                // If `prefix_idx >= rlp_len`, that means we are done
+                //let item_in_list = self.range.is_less_than(
+                //    ctx,
+                //    prefix_idx,
+                //    rlp_len,
+                //    bit_length(max_rlp_array_len as u64),
+                //);
+                // In cases where the RLP sequence is a list of unknown variable length, we keep track
+                // of whether the corresponding index actually is a list item by constraining that
+                // all of `prefix_len, len_len, field_len` are 0 when the current field should be treated
+                // as a dummy and not actually in the list
+                prefix_len = self.gate().mul(ctx, prefix_len, item_in_list);
+                len_len = self.gate().mul(ctx, len_len, item_in_list);
+                //item_len = self.gate().mul(ctx, item_len, item_in_list);
+            }
+
+            // this is just print for debug
+            let mut prefix_idx_val = F::from(0u64);
             let mut item_len_val = F::from(0u64);
-            /*
-            prefix_idx.value().map(|x| {
-                prefix_idx_val = *x;
-            });
-            item_len.value().map(|x|  {
-                item_len_val = *x;
-            });
-            */
+
             prefix_idx_val = *prefix_idx.value();
             item_len_val = *item_len.value();
             println!("This item starts at {:?} and has length {:?}", prefix_idx_val.get_lower_32(), item_len_val.get_lower_32());
+            // if literal, is the length wrong?
+            // end print for debug
 
+
+
+            // if literal: should item_len be 1?
             self.range.check_less_than_safe(ctx, item_len, (max_item_len + 1) as u64);
+                // must be after the block
 
+            // if literal: item_len should be 1.  item_cells should have length 1
             let item_cells = witness_subarray(
                 ctx,
                 &rlp_array,
@@ -875,10 +948,8 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
             );
             running_max_len += 1 + max_item_len_len + max_item_len;
 
-            // prefix_len is either 0 or 1
-            let mut prefix_len = prefix_parsed.is_not_literal;
 
-            // here we need to handle is_variable_len
+
 
             prefix = self.gate().mul(ctx, Existing(prefix), Existing(prefix_len));
             prefix_idx = self.gate().sum(
@@ -905,9 +976,6 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
             item_witness.push(witness);
         }
 
-        //println!("End decompose_rlp_of_rlp_phase0");
-
-
         RlpOfRlpTraceWitness { item_witness, len_len, len_cells, rlp_len, rlp_array }
 
     }
@@ -919,7 +987,6 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         rlp_witness: RlpOfRlpTraceWitness<F>,
         _is_variable_len: bool,
     ) -> RlpOfRlpTrace<F> {
-        //println!("Start decompose_rlp_of_rlp_phase1");
 
         // TO VERIFY
         // 1. parse_rlp_len -- gives len_cells from rlp_array and len_len
@@ -933,6 +1000,8 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
         let len_trace = rlc.compute_rlc((ctx_gate, ctx_rlc), self.gate(), len_cells, len_len);
 
         let mut item_trace = Vec::with_capacity(item_witness.len());
+        let mut cml_max_len: usize = 0;
+
         for item_witness in item_witness {
             let len_rlc = rlc.compute_rlc(
                 (ctx_gate, ctx_rlc),
@@ -952,10 +1021,11 @@ impl<'range, F: ScalarField> RlpChip<'range, F> {
                 len_trace: len_rlc,
                 item_trace: item_rlc,
             });
+            cml_max_len += item_witness.max_item_len;
         }
 
 
-        rlc.load_rlc_cache((ctx_gate, ctx_rlc), self.gate(), bit_length(rlp_array.len() as u64));
+        rlc.load_rlc_cache((ctx_gate, ctx_rlc), self.gate(), cml_max_len);
 
         let prefix = rlp_array[0];
         let one = ctx_gate.load_constant(F::one());

--- a/axiom-eth/src/rlp/rlc.rs
+++ b/axiom-eth/src/rlp/rlc.rs
@@ -222,6 +222,7 @@ impl<F: ScalarField> RlcChip<F> {
 
         let (mut running_rlc, mut running_len, _) = inputs.next().unwrap();
         for (input, len, max_len) in inputs {
+            println!("Looping 225: {:?}", max_len);
             running_len = gate.add(ctx_gate, running_len, len);
             let gamma_pow = self.rlc_pow(ctx_gate, gate, len, bit_length(max_len as u64));
             running_rlc = gate.mul_add(ctx_gate, running_rlc, gamma_pow, input);
@@ -331,6 +332,7 @@ impl<F: ScalarField> RlcChip<F> {
         if pow_bits == 0 {
             pow_bits = 1;
         }
+        println!("assertion {}>={}", self.gamma_pow_cached().len(), pow_bits);
         assert!(pow_bits <= self.gamma_pow_cached().len());
 
         let bits = gate.num_to_bits(ctx_gate, pow, pow_bits);

--- a/axiom-eth/src/rlp/rlc.rs
+++ b/axiom-eth/src/rlp/rlc.rs
@@ -222,7 +222,6 @@ impl<F: ScalarField> RlcChip<F> {
 
         let (mut running_rlc, mut running_len, _) = inputs.next().unwrap();
         for (input, len, max_len) in inputs {
-            println!("Looping 225: {:?}", max_len);
             running_len = gate.add(ctx_gate, running_len, len);
             let gamma_pow = self.rlc_pow(ctx_gate, gate, len, bit_length(max_len as u64));
             running_rlc = gate.mul_add(ctx_gate, running_rlc, gamma_pow, input);
@@ -332,7 +331,6 @@ impl<F: ScalarField> RlcChip<F> {
         if pow_bits == 0 {
             pow_bits = 1;
         }
-        println!("assertion {}>={}", self.gamma_pow_cached().len(), pow_bits);
         assert!(pow_bits <= self.gamma_pow_cached().len());
 
         let bits = gate.num_to_bits(ctx_gate, pow, pow_bits);

--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -465,6 +465,19 @@ mod rlp {
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
     }
 
+    #[test] // pass
+    pub fn test_mock_rlp_array_3() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = vec![0xc3, 0x00, 0x00, 0x00,];
+        let circuit = rlp_list_circuit(
+            RlcThreadBuilder::<Fr>::mock(), 
+            input_bytes, 
+            &[5, 5, 5],
+            true,
+        );
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
 
     #[test]
     pub fn test_mock_rlp_field() {
@@ -634,6 +647,18 @@ mod rlp {
     pub fn test_mock_rlp_of_rlp_9() {
         let k = DEGREE;
         let input_bytes: Vec<u8> = Vec::from_hex("c100").unwrap();
+        // list consists of a single string literal
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_10() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c100000000000000").unwrap();
         // list consists of a single string literal
         let max_field_lens = vec![100, 100, 100];
         let is_var_len = true;

--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -505,20 +505,24 @@ mod rlp {
             RlcThreadBuilder::keygen(), input_bytes.clone(), &max_field_lens, is_var_len
         );
 
+        circuit.config(k as usize, Some(6));
 
 
-        println!("vk gen started"); // 7:30-ish to here -- 11:23
+        println!("vk gen started");
         let vk = keygen_vk(&params, &circuit)?;
         println!("vk gen done");
         let pk = keygen_pk(&params, vk, &circuit)?;
         println!("pk gen done");
         println!();
-        println!("==============STARTING PROOF GEN==================="); // 9:40 to here -- 13:20
+        println!("==============STARTING PROOF GEN==================="); 
+
+        let break_points = circuit.0.break_points.take();
 
         drop(circuit);
         let circuit = rlp_circuit(
             RlcThreadBuilder::prover(), input_bytes.clone(), &max_field_lens, is_var_len
         );
+        *circuit.0.break_points.borrow_mut() = break_points;
 
 
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);

--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -439,6 +439,33 @@ mod rlp {
         }
     }
 
+    #[test] // fail
+    pub fn test_mock_rlp_array_1() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g'];
+        let circuit = rlp_list_circuit(
+            RlcThreadBuilder::<Fr>::mock(), 
+            input_bytes, 
+            &[100, 100], 
+            true,
+        );
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test] // fail
+    pub fn test_mock_rlp_array_2() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g'];
+        let circuit = rlp_list_circuit(
+            RlcThreadBuilder::<Fr>::mock(), 
+            input_bytes, 
+            &[5, 5, 5],
+            true,
+        );
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+
     #[test]
     pub fn test_mock_rlp_field() {
         let k = DEGREE;

--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -486,6 +486,102 @@ mod rlp {
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
     }
 
+    // TESTS
+    // need to test: byte literal, len literal for item, len len for item,
+    // len literal for list, len len for list
+
+    // list of three literals: one byte, one len, one len len
+    // list of two lists: one len, one len len
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_1() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("f8472083000000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        //let input_bytes: Vec<u8> = Vec::from_hex("f842b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        //let input_bytes: Vec<u8> = Vec::from_hex("f845820000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        // does not appear to work when one item is a byte literal
+        // [(1-byte str), (3-byte str), (64-byte str)] -- tot 71-byte payload
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_2() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = vec![0xd7, 0x84, b'n', b'u', b'm', b's',
+        0xc8, 0x83, b'o', b'n', b'e', 0x83, b't', b'w', b'o',
+        0xc8, 0x83, b'u', b'n', b'o', 0x83, b'd', b'o', b's'];
+        let max_field_lens = vec![15, 9, 11];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_3() {
+        // list of two lists: one len, one len len
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("f852c88300000083000000f8472083000000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_4() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
+
+        let max_field_lens = vec![200, 200]; // with 4 20's it fails
+        let is_var_len = false;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_5() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
+
+        let max_field_lens = vec![200, 200]; // with 4 20's it fails
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_6() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
+
+        let max_field_lens = vec![200, 200, 200, 200]; // with 4 20's it fails
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_7() {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c100").unwrap();
+        // [(1-byte str), (3-byte str), (64-byte str)] -- tot 71-byte payload
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+
     #[test]
     pub fn test_prove_rlp_of_rlp_2() -> Result<(), Error> {
         let k = DEGREE;

--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -487,20 +487,15 @@ mod rlp {
     }
 
     // TESTS
-    // need to test: byte literal, len literal for item, len len for item,
+    // test: byte literal, len literal for item, len len for item,
     // len literal for list, len len for list
-
-    // list of three literals: one byte, one len, one len len
-    // list of two lists: one len, one len len
 
     #[test]
     pub fn test_mock_rlp_of_rlp_1() {
+        // list of three literals: one byte, one len, one len len
         let k = DEGREE;
         let input_bytes: Vec<u8> = Vec::from_hex("f8472083000000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
-        //let input_bytes: Vec<u8> = Vec::from_hex("f842b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
-        //let input_bytes: Vec<u8> = Vec::from_hex("f845820000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
-        // does not appear to work when one item is a byte literal
-        // [(1-byte str), (3-byte str), (64-byte str)] -- tot 71-byte payload
+        // [(1-byte literal), (3-byte str), (64-byte str)] -- tot 71-byte payload
         let max_field_lens = vec![100, 100, 100];
         let is_var_len = true;
 
@@ -514,6 +509,7 @@ mod rlp {
         let input_bytes: Vec<u8> = vec![0xd7, 0x84, b'n', b'u', b'm', b's',
         0xc8, 0x83, b'o', b'n', b'e', 0x83, b't', b'w', b'o',
         0xc8, 0x83, b'u', b'n', b'o', 0x83, b'd', b'o', b's'];
+        // ["nums", ["one", "two"], ["uno", "dos"]]
         let max_field_lens = vec![15, 9, 11];
         let is_var_len = true;
 
@@ -533,13 +529,16 @@ mod rlp {
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
     }
 
+
+
+
     #[test]
     pub fn test_mock_rlp_of_rlp_4() {
         let k = DEGREE;
-        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
-
-        let max_field_lens = vec![200, 200]; // with 4 20's it fails
-        let is_var_len = false;
+        let input_bytes: Vec<u8> = Vec::from_hex("c0").unwrap();
+        // empty list
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
 
         let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
@@ -547,23 +546,28 @@ mod rlp {
 
     #[test]
     pub fn test_mock_rlp_of_rlp_5() {
+        // set-theoretical representation of three
+        // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
         let k = DEGREE;
-        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
-
-        let max_field_lens = vec![200, 200]; // with 4 20's it fails
+        let input_bytes: Vec<u8> = Vec::from_hex("c7c0c1c0c3c0c1c0").unwrap();
+        let max_field_lens = vec![100, 100, 100, 100, 100];
         let is_var_len = true;
 
         let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
     }
 
+
+
     #[test]
     pub fn test_mock_rlp_of_rlp_6() {
+        // list of two string literals
+        // is_var_len == false
         let k = DEGREE;
         let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
 
-        let max_field_lens = vec![200, 200, 200, 200]; // with 4 20's it fails
-        let is_var_len = true;
+        let max_field_lens = vec![200, 200];
+        let is_var_len = false;
 
         let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
@@ -571,15 +575,113 @@ mod rlp {
 
     #[test]
     pub fn test_mock_rlp_of_rlp_7() {
+        // list of two string literals
+        // is_var_len == true, 
+        // no phantom items
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
+
+        let max_field_lens = vec![200, 200];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_8() {
+        // list of two string literals
+        // is_var_len == true,
+        // phantom items
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c88300000083000000").unwrap();
+
+        let max_field_lens = vec![200, 200, 200, 200];
+        let is_var_len = true;
+
+        let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
+        MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
+    }
+
+    #[test]
+    pub fn test_mock_rlp_of_rlp_9() {
         let k = DEGREE;
         let input_bytes: Vec<u8> = Vec::from_hex("c100").unwrap();
-        // [(1-byte str), (3-byte str), (64-byte str)] -- tot 71-byte payload
+        // list consists of a single string literal
         let max_field_lens = vec![100, 100, 100];
         let is_var_len = true;
 
         let circuit = rlp_circuit(RlcThreadBuilder::<Fr>::mock(), input_bytes, &max_field_lens, is_var_len);
         MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
     }
+
+
+
+
+    #[test]
+    pub fn test_prove_rlp_of_rlp_1() -> Result<(), Error> {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("f8472083000000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        // [(1-byte literal), (3-byte str), (64-byte str)] -- tot 71-byte payload
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+
+        
+        println!("Length of input is ... {:?}", input_bytes.len());
+        println!("Input string: {:?}", input_bytes);
+
+        let mut rng = StdRng::from_seed([0u8; 32]);
+        let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::keygen(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+
+        circuit.config(k as usize, Some(6));
+
+
+        println!("vk gen started");
+        let vk = keygen_vk(&params, &circuit)?;
+        println!("vk gen done");
+        let pk = keygen_pk(&params, vk, &circuit)?;
+        println!("pk gen done");
+        println!();
+        println!("==============STARTING PROOF GEN==================="); 
+
+        let break_points = circuit.0.break_points.take();
+
+        drop(circuit);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::prover(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+        *circuit.0.break_points.borrow_mut() = break_points;
+
+
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            _,
+            Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
+            _,
+        >(&params, &pk, &[circuit], &[&[]], rng, &mut transcript)?;
+        let proof = transcript.finalize();
+        println!("proof gen done");
+        let verifier_params = params.verifier_params();
+        let strategy = SingleStrategy::new(verifier_params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        assert!(verify_proof::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
+            SingleStrategy<'_, Bn256>,
+        >(verifier_params, pk.get_vk(), strategy, &[&[]], &mut transcript)
+        .is_ok());
+        println!("verify done");
+        Ok(())
+    }
+
 
 
     #[test]
@@ -592,6 +694,203 @@ mod rlp {
         let max_field_lens = vec![15, 9, 11];
         let is_var_len = false;
         
+        println!("Length of input is ... {:?}", input_bytes.len());
+        println!("Input string: {:?}", input_bytes);
+
+        let mut rng = StdRng::from_seed([0u8; 32]);
+        let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::keygen(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+
+        circuit.config(k as usize, Some(6));
+
+
+        println!("vk gen started");
+        let vk = keygen_vk(&params, &circuit)?;
+        println!("vk gen done");
+        let pk = keygen_pk(&params, vk, &circuit)?;
+        println!("pk gen done");
+        println!();
+        println!("==============STARTING PROOF GEN==================="); 
+
+        let break_points = circuit.0.break_points.take();
+
+        drop(circuit);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::prover(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+        *circuit.0.break_points.borrow_mut() = break_points;
+
+
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            _,
+            Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
+            _,
+        >(&params, &pk, &[circuit], &[&[]], rng, &mut transcript)?;
+        let proof = transcript.finalize();
+        println!("proof gen done");
+        let verifier_params = params.verifier_params();
+        let strategy = SingleStrategy::new(verifier_params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        assert!(verify_proof::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
+            SingleStrategy<'_, Bn256>,
+        >(verifier_params, pk.get_vk(), strategy, &[&[]], &mut transcript)
+        .is_ok());
+        println!("verify done");
+        Ok(())
+    }
+
+
+
+    #[test]
+    pub fn test_prove_rlp_of_rlp_3() -> Result<(), Error> {
+        let k = DEGREE;
+        // list of two lists: one len, one len len
+        let input_bytes: Vec<u8> = Vec::from_hex("f852c88300000083000000f8472083000000b84000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+        
+        println!("Length of input is ... {:?}", input_bytes.len());
+        println!("Input string: {:?}", input_bytes);
+
+        let mut rng = StdRng::from_seed([0u8; 32]);
+        let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::keygen(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+
+        circuit.config(k as usize, Some(6));
+
+
+        println!("vk gen started");
+        let vk = keygen_vk(&params, &circuit)?;
+        println!("vk gen done");
+        let pk = keygen_pk(&params, vk, &circuit)?;
+        println!("pk gen done");
+        println!();
+        println!("==============STARTING PROOF GEN==================="); 
+
+        let break_points = circuit.0.break_points.take();
+
+        drop(circuit);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::prover(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+        *circuit.0.break_points.borrow_mut() = break_points;
+
+
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            _,
+            Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
+            _,
+        >(&params, &pk, &[circuit], &[&[]], rng, &mut transcript)?;
+        let proof = transcript.finalize();
+        println!("proof gen done");
+        let verifier_params = params.verifier_params();
+        let strategy = SingleStrategy::new(verifier_params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        assert!(verify_proof::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
+            SingleStrategy<'_, Bn256>,
+        >(verifier_params, pk.get_vk(), strategy, &[&[]], &mut transcript)
+        .is_ok());
+        println!("verify done");
+        Ok(())
+    }
+
+
+
+    #[test]
+    pub fn test_prove_rlp_of_rlp_4() -> Result<(), Error> {
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c0").unwrap();
+        // empty list
+        let max_field_lens = vec![100, 100, 100];
+        let is_var_len = true;
+        
+        println!("Length of input is ... {:?}", input_bytes.len());
+        println!("Input string: {:?}", input_bytes);
+
+        let mut rng = StdRng::from_seed([0u8; 32]);
+        let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::keygen(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+
+        circuit.config(k as usize, Some(6));
+
+
+        println!("vk gen started");
+        let vk = keygen_vk(&params, &circuit)?;
+        println!("vk gen done");
+        let pk = keygen_pk(&params, vk, &circuit)?;
+        println!("pk gen done");
+        println!();
+        println!("==============STARTING PROOF GEN==================="); 
+
+        let break_points = circuit.0.break_points.take();
+
+        drop(circuit);
+        let circuit = rlp_circuit(
+            RlcThreadBuilder::prover(), input_bytes.clone(), &max_field_lens, is_var_len
+        );
+        *circuit.0.break_points.borrow_mut() = break_points;
+
+
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            _,
+            Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
+            _,
+        >(&params, &pk, &[circuit], &[&[]], rng, &mut transcript)?;
+        let proof = transcript.finalize();
+        println!("proof gen done");
+        let verifier_params = params.verifier_params();
+        let strategy = SingleStrategy::new(verifier_params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        assert!(verify_proof::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<'_, Bn256>,
+            Challenge255<G1Affine>,
+            Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
+            SingleStrategy<'_, Bn256>,
+        >(verifier_params, pk.get_vk(), strategy, &[&[]], &mut transcript)
+        .is_ok());
+        println!("verify done");
+        Ok(())
+    }
+
+
+
+    #[test]
+    pub fn test_prove_rlp_of_rlp_5() -> Result<(), Error> {
+        let k = DEGREE;
+        // set-theoretical representation of three
+        // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+        let k = DEGREE;
+        let input_bytes: Vec<u8> = Vec::from_hex("c7c0c1c0c3c0c1c0").unwrap();
+        let max_field_lens = vec![100, 100, 100, 100, 100];
+        let is_var_len = true;
+
         println!("Length of input is ... {:?}", input_bytes.len());
         println!("Input string: {:?}", input_bytes);
 


### PR DESCRIPTION
Decompose an arbitrary RLP into a list of items.

Additionally, fix two bugs in decompose_rlp_array_phase0() and decompose_rlp_array_phase1(), and add several tests.