### PR TITLE
Start pinning deps

### DIFF
--- a/axiom-eth/Cargo.toml
+++ b/axiom-eth/Cargo.toml
@@ -12,22 +12,23 @@ itertools = "0.10"
 lazy_static = "1.4.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-rayon = "1.7"
+rayon = "1.6"
 
 # misc
 log = "0.4"
 env_logger = "0.10"
 ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
-clap = { version = "4.0.13", features = ["derive"], optional = true }
+clap = { version = "=4.0.13", features = ["derive"], optional = true }
 clap-num = { version = "1.0.2", optional = true }
+clap_lex = { version = "=0.5.0", optional = true }
 bincode = { version = "1.3.3", optional = true }
 base64 = { version = "0.21", optional = true }
 serde_with = { version = "2.2", optional = true }
 
 # halo2
 ff = "0.12"
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", branch = "community-edition", default-features = false }
-zkevm-keccak = { git = "https://github.com/axiom-crypto/halo2-lib.git", branch = "community-edition", default-features = false }
+halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.3.0-ce", default-features = false }
+zkevm-keccak = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.3.0-ce", default-features = false }
 # macro
 any_circuit_derive = { path = "../any_circuit_derive", optional = true }
 


### PR DESCRIPTION
Due to the newly pinned dependencies in `halo2-lib`, cargo fails to resolve compatible dependency versions. It starts with `rayon` which is pinned to `1.6.1` in `halo2-lib` and here is required to be >1.7.

I'd like to move to 0.4 on `halo2-lib` soon, but before I can do that, in the meantime I need to rely on `v0.3.0-ce`. It would be good for all related repos to have the same tag which is compatible with the other repos.

Unfortunately this PR doesn't fix the full extent of the problem, now I run into:
```
error[E0277]: the trait bound `halo2_base::gates::builder::RangeWithInstanceCircuitBuilder<F>: CircuitExt<F>` is not satisfied
  --> axiom-eth/src/util/circuit.rs:55:22
   |
55 | impl<F: ScalarField> PinnableCircuit<F> for RangeWithInstanceCircuitBuilder<F> {
   |                      ^^^^^^^^^^^^^^^^^^ the trait `CircuitExt<F>` is not implemented for `halo2_base::gates::builder::RangeWithInstanceCircuitBuilder<F>`
   |
```

which is the issue on `snark-verifier` side, I believe? I'm failing to see how to fix this though.