### PR TITLE
Use challenge API for polynomial evaluation

### DIFF
--- a/axiom-eth/src/rlp/tests.rs
+++ b/axiom-eth/src/rlp/tests.rs
@@ -149,8 +149,6 @@ mod rlc {
             assert_eq!(real_poly_b_eval, poly_b_eval_value);
             assert_eq!(real_poly_c_eval, poly_c_eval_value);
 
-            gate.is_equal(ctx_gate, poly_a_eval_assigned, poly_b_eval_assigned);
-
             // enforce gate a(gamma) * b(gamma) - c(gamma) = 0
             ctx_gate.assign_region(
                 [


### PR DESCRIPTION
At the state-of-the-art, constraining a polynomial identity using halo2_base has `O(n)` complexity (where `n` is the degree of the polynomial). 

Constraining a polynomial multiplication has `O(n^2)` complexity as it can only be performed using the direct method. 

Following [a conversation with @yi-sun on Discord](https://discord.com/channels/1028547935195119617/1085283481409556500/1158112616552616078) we realized that the challenge API can be used to efficiently evaluate polynomial identities.

Any polynomial identity can be checked in this way e.g. `p(x) = q(x)` with high probability if `p(gamma) = q(gamma)` for a challenge gamma because a random gamma has vanishing probability of being a root of `p(x) - q(x)`.

Despite the original idea was to create a customized chip to perform such operation, while digging into the [documentation of the challenge API](https://hackmd.io/@axiom/SJw3p-qX3) I realized that the gate designed for the `RlcChip` could be reused for Polynomial Evaluation. 

Therefore the PR doesn't contain any modification to the core logic of the library, it only adds a test that constraints a polynomial multiplication via the challenge API using the `RlcChip`

The test can be reproduced via `cargo test --release test_mock_poly_eval`

The goal of the PR is twofold: 

- Request review for the proposed implementation
- Request advice on how to pack this implementation in an example that might help other people to reuse it

The goal of the PR is not necessarily to have it merged into `axiom-eth`