### PR TITLE
change RlpCircuitBuilder to pub RlcCircuitBuilder

### DIFF
--- a/axiom-eth/src/rlp/builder.rs
+++ b/axiom-eth/src/rlp/builder.rs
@@ -608,7 +608,7 @@ mod circuit_builder {
     }
 
     /// A wrapper around RlcCircuitBuilder where Gate is replaced by Range in the circuit
-    pub struct RlpCircuitBuilder<F: ScalarField, FnPhase1>(RlcCircuitBuilder<F, FnPhase1>)
+    pub struct RlpCircuitBuilder<F: ScalarField, FnPhase1>(pub RlcCircuitBuilder<F, FnPhase1>)
     where
         FnPhase1: FnSynthesize<F>;
 


### PR DESCRIPTION
Access to RlcCircuitBuilder inside RlpCircuitBuilder seems to be required for proof generation. Specifically, one needs this to exchange break_points as in [here](https://github.com/axiom-crypto/axiom-eth/blob/2d3a9333ef6d183a4c0411b9a5078f9bcf967467/axiom-eth/src/rlp/tests.rs#L274). A test is added to show proof generation.

