### PR TITLE
[feat] update block RLP fetching for Dencun

### DIFF
--- a/axiom-codec/Cargo.toml
+++ b/axiom-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-codec"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"
@@ -19,7 +19,7 @@ serde_with = { version = "2.2", optional = true }
 anyhow = "1.0"
 
 # halo2, features turned on by axiom-eth
-axiom-eth = { version = "=0.4.0", path = "../axiom-eth", default-features = false }
+axiom-eth = { version = "0.4.1", path = "../axiom-eth", default-features = false }
 
 # ethereum
 ethers-core = { version = "2.0.10" }

--- a/axiom-core/Cargo.toml
+++ b/axiom-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-core"
-version = "2.0.12"
+version = "2.0.13"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"
@@ -29,7 +29,7 @@ anyhow = "1.0"
 hex = "0.4.3"
 
 # halo2, features turned on by axiom-eth
-axiom-eth = { version = "=0.4.0", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
+axiom-eth = { version = "=0.4.1", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
 
 # crypto
 ethers-core = { version = "=2.0.10" }

--- a/axiom-eth/Cargo.toml
+++ b/axiom-eth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-eth"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"
@@ -35,7 +35,7 @@ zkevm-hashes = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v
 
 # crypto
 rlp = "=0.5.2"
-ethers-core = { version = "2.0.10" }
+ethers-core = { version = "=2.0.10" } # fix the version as it affects what fields are included in the `Block` struct
 # mpt implementation
 hasher = { version = "=0.1", features = ["hash-keccak"] }
 cita_trie = "=5.0.0"
@@ -53,7 +53,7 @@ snark-verifier = { git = "https://github.com/axiom-crypto/snark-verifier.git", t
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.1.7-git", default-features = false }
 
 # generating circuit inputs from blockchain
-ethers-providers = { version = "2.0.10", optional = true }
+ethers-providers = { version = "=2.0.10", optional = true }
 tokio = { version = "1.28", default-features = false, features = ["rt", "rt-multi-thread", "macros"], optional = true }
 futures = { version = "0.3", optional = true }
 

--- a/axiom-eth/src/providers/block.rs
+++ b/axiom-eth/src/providers/block.rs
@@ -133,7 +133,7 @@ mod tests {
 
         let rt = Runtime::new().unwrap();
         let latest = rt.block_on(provider.get_block_number()).unwrap();
-        for block_num in [0, 5000050, 5187810, 5187814, latest.as_u64()] {
+        for block_num in [0, 5000050, 5187023, 5187810, 5187814, latest.as_u64()] {
             let block = rt.block_on(provider.get_block(block_num)).unwrap().unwrap();
             get_block_rlp(&block);
         }

--- a/axiom-eth/src/providers/mod.rs
+++ b/axiom-eth/src/providers/mod.rs
@@ -20,6 +20,7 @@ pub fn setup_provider(chain: Chain) -> Provider<RetryClient<Http>> {
     Provider::new_client(&provider_uri, 10, 500).expect("could not instantiate HTTP Provider")
 }
 
+/// Version of `Vec::from_hex` that works with odd-length strings. Assumes string does not start with `0x` and only has hex characters.
 pub fn from_hex(s: &str) -> Vec<u8> {
     let s = if s.len() % 2 == 1 { format!("0{s}") } else { s.to_string() };
     Vec::from_hex(s).unwrap()

--- a/axiom-query/Cargo.toml
+++ b/axiom-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-query"
-version = "2.0.14"
+version = "2.0.15"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"
@@ -35,8 +35,8 @@ rand = "0.8"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 # halo2, features turned on by axiom-eth
-axiom-eth = { version = "=0.4.0", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
-axiom-codec = { version = "0.2.0", path = "../axiom-codec", default-features = false }
+axiom-eth = { version = "=0.4.1", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
+axiom-codec = { version = "0.2.1", path = "../axiom-codec", default-features = false }
 
 # crypto
 rlp = "0.5.2"


### PR DESCRIPTION
No ZK circuit changes were made.

We update the `get_block_rlp` function in `axiom_eth::providers::block`
so it will correctly calculate the RLP of blocks with the new fields
from EIP-4844 and EIP-4788. We must fetch these fields from the
`block.other` BTreeMap since `ethers-rs` has also not updated to handle
these.