### PR TITLE
feat: clear virtual phase0 columns in builder before next phase (#295)

### DIFF
--- a/axiom-eth/Cargo.toml
+++ b/axiom-eth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-eth"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"

--- a/axiom-query/Cargo.toml
+++ b/axiom-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-query"
-version = "2.0.16"
+version = "2.0.17"
 authors = ["Intrinsic Technologies"]
 license = "MIT"
 edition = "2021"
@@ -35,7 +35,7 @@ rand = "0.8"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 # halo2, features turned on by axiom-eth
-axiom-eth = { version = "=0.4.2", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
+axiom-eth = { version = "0.4.3", path = "../axiom-eth", default-features = false, features = ["providers", "aggregation", "evm"] }
 axiom-codec = { version = "0.2.1", path = "../axiom-codec", default-features = false }
 
 # crypto


### PR DESCRIPTION
* feat: clear virtual phase0 columns in builder before next phase

In prover stage, these columns should never be touched again once they have been raw assigned. This should save memory before the real phase0 assigned columns are KZG commited (MSM leads to memory spike).

* chore: bump axiom-eth v0.4.3, axiom-query v2.0.17